### PR TITLE
LinearGauge: fix bounds check in stepNeg()

### DIFF
--- a/widgets/LinearGauge/LinearGauge.cpp
+++ b/widgets/LinearGauge/LinearGauge.cpp
@@ -176,7 +176,7 @@ void LinearGauge::stepPos()
 
 void LinearGauge::stepNeg()
 {
-  if(currentVal-stepSize >= 0 )
+  if(currentVal-stepSize >= lowerBound )
   {
     currentVal-=stepSize;
   }


### PR DESCRIPTION
should this be compared against _lowerBound_ instead of _0_ ?